### PR TITLE
Adding KLB package for MAI-400 Kubos service

### DIFF
--- a/package/kubos/Config.in
+++ b/package/kubos/Config.in
@@ -12,5 +12,7 @@ if BR2_PACKAGE_KUBOS
 		help
 			Release, tag, or branch of the Kubos repo to use when building Kubos
 			packages
+			
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-mai400/Config.in"
 
 endif

--- a/package/kubos/kubos-mai400/Config.in
+++ b/package/kubos/kubos-mai400/Config.in
@@ -1,6 +1,7 @@
 menuconfig BR2_PACKAGE_KUBOS_MAI400
-    bool "MAI-400"
+    bool "MAI-400 Service"
     default n
+    select BR2_PACKAGE_HAS_KUBOS_MAI400
     help
         Include MAI-400 Kubos service.
 
@@ -16,3 +17,10 @@ config BR2_KUBOS_MAI400_INIT_LVL
         The lower the number, the earlier the service is initialized.
 
 endif
+
+config BR2_PACKAGE_HAS_KUBOS_MAI400
+    bool
+
+config BR2_PACKAGE_PROVIDES_KUBOS_MAI400
+    string
+    default "kubos"

--- a/package/kubos/kubos-mai400/Config.in
+++ b/package/kubos/kubos-mai400/Config.in
@@ -1,0 +1,18 @@
+menuconfig BR2_PACKAGE_KUBOS_MAI400
+    bool "MAI-400"
+    default n
+    help
+        Include MAI-400 Kubos service.
+
+if BR2_PACKAGE_KUBOS_MAI400
+
+config BR2_KUBOS_MAI400_INIT_LVL
+    int "MAI-400 Service Run Level"
+    default 90
+    range 10 99
+    depends on BR2_PACKAGE_KUBOS_MAI400
+    help
+        The initialization priority level of the MAI-400 Kubos service.
+        The lower the number, the earlier the service is initialized.
+
+endif

--- a/package/kubos/kubos-mai400/kubos-mai400
+++ b/package/kubos/kubos-mai400/kubos-mai400
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+NAME=mai400-service
+PROG=/usr/sbin/${NAME}
+PID=/var/run/${NAME}.pid
+
+case "$1" in
+    start)
+    echo "Starting ${NAME}: "
+    start-stop-daemon -S -q -m -b -p ${PID} --exec ${PROG}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    stop)
+    echo "Stopping ${NAME}: "
+    start-stop-daemon -K -q -p ${PID}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    restart)
+    "$0" stop
+    "$0" start
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart}"
+    ;;
+esac
+
+exit $rc

--- a/package/kubos/kubos-mai400/kubos-mai400.mk
+++ b/package/kubos/kubos-mai400/kubos-mai400.mk
@@ -3,42 +3,28 @@
 # Kubos MAI400 Service
 #
 ###############################################
-KUBOS_MAI400_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
-KUBOS_MAI400_LICENSE = Apache-2.0
-KUBOS_MAI400_LICENSE_FILES = LICENSE
-KUBOS_MAI400_SITE = $(BUILD_DIR)/kubos-$(KUBOS_MAI400_VERSION)/services/mai400-service
-KUBOS_MAI400_SITE_METHOD = local
-KUBOS_MAI400_DEPENDENCIES = kubos
-# The path from the MAI400 module to the build artifact directory
-KUBOS_ARTIFACT_BUILD_PATH = target/$(CARGO_TARGET)/release
 
-# Use the Kubos SDK to build the MAI400 application
-define KUBOS_MAI400_BUILD_CMDS
-	cd $(@D) && \
+KUBOS_MAI400_POST_BUILD_HOOKS += MAI400_BUILD_CMDS
+KUBOS_MAI400_POST_INSTALL_TARGET_HOOKS += MAI400_INSTALL_TARGET_CMDS
+KUBOS_MAI400_POST_INSTALL_TARGET_HOOKS += MAI400_INSTALL_INIT_SYSV
+
+define MAI400_BUILD_CMDS
+	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/mai400-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	cargo build --target $(CARGO_TARGET) --release && \
-	arm-linux-strip $(KUBOS_ARTIFACT_BUILD_PATH)/mai400-service
+	cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system
-define KUBOS_MAI400_INSTALL_TARGET_CMDS
+define MAI400_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/sbin
-	$(INSTALL) -D -m 0755 $(@D)/$(KUBOS_ARTIFACT_BUILD_PATH)/mai400-service \
+	$(INSTALL) -D -m 0755 $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/$(CARGO_OUTPUT_DIR)/mai400-service \
 		$(TARGET_DIR)/usr/sbin
 endef
 
 # Install the init script
-define KUBOS_MAI400_INSTALL_INIT_SYSV
+define MAI400_INSTALL_INIT_SYSV
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_KUBOS_LINUX_PATH)/package/kubos/kubos-mai400/kubos-mai400 \
 	    $(TARGET_DIR)/etc/init.d/S$(BR2_KUBOS_MAI400_INIT_LVL)kubos-mai400
 endef
 
-kubos-mai400-fullclean: kubos-mai400-clean kubos-mai400-clean-for-reconfigure kubos-mai400-dirclean
-	rm -f $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION)/.stamp_downloaded
-	rm -f $(DL_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION).tar.gz
-
-kubos-mai400-clean: kubos-mai400-clean-for-rebuild
-	cd $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION); PATH=$(PATH):~/.cargo/bin cargo clean
-	cd $(TARGET_DIR)/etc/init.d; rm -f S*kubos-mai400
-
-$(eval $(generic-package))
+$(eval $(virtual-package))

--- a/package/kubos/kubos-mai400/kubos-mai400.mk
+++ b/package/kubos/kubos-mai400/kubos-mai400.mk
@@ -6,15 +6,16 @@
 KUBOS_MAI400_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
 KUBOS_MAI400_LICENSE = Apache-2.0
 KUBOS_MAI400_LICENSE_FILES = LICENSE
-KUBOS_MAI400_SITE = $(BUILD_DIR)/kubos-$(KUBOS_MAI400_VERSION)/mai400-service
+KUBOS_MAI400_SITE = $(BUILD_DIR)/kubos-$(KUBOS_MAI400_VERSION)/services/mai400-service
 KUBOS_MAI400_SITE_METHOD = local
 KUBOS_MAI400_DEPENDENCIES = kubos
 # The path from the MAI400 module to the build artifact directory
-KUBOS_ARTIFACT_BUILD_PATH = ../../target/$(CARGO_TARGET)/release
+KUBOS_ARTIFACT_BUILD_PATH = target/$(CARGO_TARGET)/release
 
 # Use the Kubos SDK to build the MAI400 application
 define KUBOS_MAI400_BUILD_CMDS
 	cd $(@D) && \
+	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
 	cargo build --target $(CARGO_TARGET) --release && \
 	arm-linux-strip $(KUBOS_ARTIFACT_BUILD_PATH)/mai400-service
 endef
@@ -36,9 +37,8 @@ kubos-mai400-fullclean: kubos-mai400-clean kubos-mai400-clean-for-reconfigure ku
 	rm -f $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION)/.stamp_downloaded
 	rm -f $(DL_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION).tar.gz
 
-
 kubos-mai400-clean: kubos-mai400-clean-for-rebuild
-	cd $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION); cargo clean
+	cd $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION); PATH=$(PATH):~/.cargo/bin cargo clean
 	cd $(TARGET_DIR)/etc/init.d; rm -f S*kubos-mai400
 
 $(eval $(generic-package))

--- a/package/kubos/kubos-mai400/kubos-mai400.mk
+++ b/package/kubos/kubos-mai400/kubos-mai400.mk
@@ -1,0 +1,44 @@
+###############################################
+#
+# Kubos MAI400 Service
+#
+###############################################
+KUBOS_MAI400_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
+KUBOS_MAI400_LICENSE = Apache-2.0
+KUBOS_MAI400_LICENSE_FILES = LICENSE
+KUBOS_MAI400_SITE = $(BUILD_DIR)/kubos-$(KUBOS_MAI400_VERSION)/mai400-service
+KUBOS_MAI400_SITE_METHOD = local
+KUBOS_MAI400_DEPENDENCIES = kubos
+# The path from the MAI400 module to the build artifact directory
+KUBOS_ARTIFACT_BUILD_PATH = ../../target/$(CARGO_TARGET)/release
+
+# Use the Kubos SDK to build the MAI400 application
+define KUBOS_MAI400_BUILD_CMDS
+	cd $(@D) && \
+	cargo build --target $(CARGO_TARGET) --release && \
+	arm-linux-strip $(KUBOS_ARTIFACT_BUILD_PATH)/mai400-service
+endef
+
+# Install the application into the rootfs file system
+define KUBOS_MAI400_INSTALL_TARGET_CMDS
+	mkdir -p $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -D -m 0755 $(@D)/$(KUBOS_ARTIFACT_BUILD_PATH)/mai400-service \
+		$(TARGET_DIR)/usr/sbin
+endef
+
+# Install the init script
+define KUBOS_MAI400_INSTALL_INIT_SYSV
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_KUBOS_LINUX_PATH)/package/kubos/kubos-mai400/kubos-mai400 \
+	    $(TARGET_DIR)/etc/init.d/S$(BR2_KUBOS_MAI400_INIT_LVL)kubos-mai400
+endef
+
+kubos-mai400-fullclean: kubos-mai400-clean kubos-mai400-clean-for-reconfigure kubos-mai400-dirclean
+	rm -f $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION)/.stamp_downloaded
+	rm -f $(DL_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION).tar.gz
+
+
+kubos-mai400-clean: kubos-mai400-clean-for-rebuild
+	cd $(BUILD_DIR)/kubos-mai400-$(KUBOS_MAI400_VERSION); cargo clean
+	cd $(TARGET_DIR)/etc/init.d; rm -f S*kubos-mai400
+
+$(eval $(generic-package))

--- a/package/kubos/kubos.mk
+++ b/package/kubos/kubos.mk
@@ -15,10 +15,13 @@ KUBOS_SITE = git://github.com/kubos/kubos
 KUBOS_BR_TARGET = $(lastword $(subst /, ,$(dir $(BR2_LINUX_KERNEL_CUSTOM_DTS_PATH))))
 ifeq ($(KUBOS_BR_TARGET),at91sam9g20isis)
 	KUBOS_TARGET = kubos-linux-isis-gcc
+	CARGO_TARGET = armv5te-unknown-linux-gnueabi
 else ifeq ($(KUBOS_BR_TARGET),pumpkin-mbm2)
 	KUBOS_TARGET = kubos-linux-pumpkin-mbm2-gcc
+	CARGO_TARGET = arm-unknown-linux-gnueabihf
 else ifeq ($(KUBOS_BR_TARGET),beaglebone-black)
 	KUBOS_TARGET = kubos-linux-beaglebone-gcc
+	CARGO_TARGET = arm-unknown-linux-gnueabihf
 else
 	KUBOS_TARGET = unknown
 endif

--- a/package/kubos/kubos.mk
+++ b/package/kubos/kubos.mk
@@ -12,6 +12,8 @@ KUBOS_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
 KUBOS_LICENSE = Apache-2.0
 KUBOS_LICENSE_FILES = LICENSE
 KUBOS_SITE = git://github.com/kubos/kubos
+KUBOS_PROVIDES = kubos-mai400
+
 KUBOS_BR_TARGET = $(lastword $(subst /, ,$(dir $(BR2_LINUX_KERNEL_CUSTOM_DTS_PATH))))
 ifeq ($(KUBOS_BR_TARGET),at91sam9g20isis)
 	KUBOS_TARGET = kubos-linux-isis-gcc
@@ -26,8 +28,10 @@ else
 	KUBOS_TARGET = unknown
 endif
 
+CARGO_OUTPUT_DIR = target/$(CARGO_TARGET)/release
+
 # Globally link all of the modules so that Kubos packages can use them
-define KUBOS_BUILD_CMDS
+define KUBOS_CONFIGURE_CMDS
 	cd $(@D) && \
 	./tools/kubos_link.py --sys
 endef
@@ -43,5 +47,6 @@ kubos-fullclean: kubos-clean-for-reconfigure kubos-dirclean
 
 
 kubos-clean: kubos-clean-for-rebuild
+	rm -fR $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/target
 
 $(eval $(generic-package))


### PR DESCRIPTION
**PR Overview**:

A Kubos service for interacting with MAI-400 ADACS has been added with kubos/kubos#61. This PR adds a KLB package to allow automated building and installation of the service.

_Note: This service is not enabled by default, since systems are not guaranteed to have an MAI-400 device present._

Additionally, the main Kubos Makefile has been updated to support a new variable `CARGO_TARGET` for use by pure-Rust Kubos packages.

**Documentation**:

- Rust docs can be manually generated for the service, but have not been included in the main Kubos docs page. [The work to enable such inclusion is still in To-Do](https://trello.com/c/EhSNE9dZ/243-integrate-rust-docs-into-main-docs)
- The change log hasn't been updated yet and will need to be changed before the next release.

**Integration Tests**:

There are currently no integration tests for Kubos services
