### PR TITLE
Adding cpio dependency to Dockerfile

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -3,6 +3,6 @@ FROM  kubos/kubos-dev:latest
 MAINTAINER kyle@kubos.co
 
 RUN apt-get install bc
-
+RUN apt-get install cpio
 RUN apt-get install ncurses-dev
 


### PR DESCRIPTION
When I updated the kubos-linux-dev Docker image to include Rust, I then ran into a missing-dependency problem when building. This PR adds the dependency (cpio)