### PR TITLE
Adding default config.toml file for Kubos services

### DIFF
--- a/common/overlay/home/system/etc/config.toml
+++ b/common/overlay/home/system/etc/config.toml
@@ -1,0 +1,44 @@
+[app-service.addr]
+ip = "0.0.0.0"
+port = 8000
+
+[clyde-3g-eps-service]
+bus = "/dev/i2c-1"
+
+[clyde-3g-eps-service.addr]
+ip = "0.0.0.0"
+port = 8001
+
+[mai400-service.addr]
+ip = "0.0.0.0"
+port = 8002
+
+[novatel-oem6-service]
+bus = "/dev/ttyS4"
+
+[novatel-oem6-service.addr]
+ip = "0.0.0.0"
+port = 8003
+
+[pumpkin-mcu-service]
+
+[pumpkin-mcu-service.modules]
+[pumpkin-mcu-service.modules.sim]
+address = 80
+[pumpkin-mcu-service.modules.gpsrm]
+address = 81
+[pumpkin-mcu-service.modules.pim]
+address = 83
+[pumpkin-mcu-service.modules.rhm]
+address = 85
+
+[pumpkin-mcu-service.addr]
+ip = "0.0.0.0"
+port = 8004
+
+[telemetry-service]
+database = "/home/system/kubos/telemetry.db"
+
+[telemetry-service.addr]
+ip = "0.0.0.0"
+port = 8005


### PR DESCRIPTION
From the Trello card:
```
Right now each KubOS Service (hardware or not) reads it's own address and port number from a section in `/home/system/etc/config.toml`. Some services (like telemetry) will actually fail to start if the config section is missing, others will fall back to `127.0.0.1:8080`. 

Long term, we need to explicitly state which service lives on what port so that there are no conflicts or user configuration required out of the box.
```

So I copied the current version of our config.toml into the `common/overlay/home/system/etc` folder with the expectation that any time a new service is made and the KLB package for it is created, this file should be updated to add the new default configuration options.

Users can then modify this file to remove or change any options they like before building it in to their KubOS image.