### PR TITLE
Adding hidden Kubos core lua package option

### DIFF
--- a/package/kubos/kubos-core/Config.in
+++ b/package/kubos/kubos-core/Config.in
@@ -7,5 +7,6 @@ menuconfig BR2_PACKAGE_KUBOS_CORE
        Include the KubOS core services
 
 if BR2_PACKAGE_KUBOS_CORE
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-lua/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-telemetry-db/Config.in"
 endif

--- a/package/kubos/kubos-core/kubos-core-lua/Config.in
+++ b/package/kubos/kubos-core/kubos-core-lua/Config.in
@@ -1,0 +1,5 @@
+menuconfig BR2_PACKAGE_KUBOS_CORE_LUA
+    bool
+    default n
+    help
+        Include the Kubos core services which are written in Lua.


### PR DESCRIPTION
The lua package is a place holder until it is broken out and converted to Rust packages. Turns out it does still need a Config.in file in order to be automatically built in >.>