### PR TITLE
Adding package for AntS service

### DIFF
--- a/common/overlay/home/system/etc/config.toml
+++ b/common/overlay/home/system/etc/config.toml
@@ -42,3 +42,14 @@ database = "/home/system/kubos/telemetry.db"
 [telemetry-service.addr]
 ip = "0.0.0.0"
 port = 8005
+
+[isis-ants-service.addr]
+ip = "0.0.0.0"
+port = 8006
+
+[isis-ants-service]
+bus = "KI2C1"
+primary = "0x31"
+secondary = "0x32"
+antennas = 4
+wd_timeout = 10

--- a/package/kubos/Config.in
+++ b/package/kubos/Config.in
@@ -14,7 +14,8 @@ if BR2_PACKAGE_KUBOS
 			packages
 
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/Config.in"
-    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-clyde-3g-eps/Config.in"	
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-clyde-3g-eps/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-isis-ants/Config.in"  	
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-mai400/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-novatel-oem6/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-pumpkin-mcu/Config.in"

--- a/package/kubos/kubos-isis-ants/Config.in
+++ b/package/kubos/kubos-isis-ants/Config.in
@@ -1,0 +1,26 @@
+menuconfig BR2_PACKAGE_KUBOS_ISIS_ANTS
+    bool "ISIS Antenna Systems Service"
+    default n
+    select BR2_PACKAGE_HAS_KUBOS_ISIS_ANTS
+    help
+        Include ISIS AntS Kubos service.
+
+if BR2_PACKAGE_KUBOS_ISIS_ANTS
+
+config BR2_KUBOS_ISIS_ANTS_INIT_LVL
+    int "ISIS AntS Service Run Level"
+    default 90
+    range 10 99
+    depends on BR2_PACKAGE_KUBOS_ISIS_ANTS
+    help
+        The initialization priority level of the ISIS AntS Kubos service.
+        The lower the number, the earlier the service is initialized.
+
+endif
+
+config BR2_PACKAGE_HAS_KUBOS_ISIS_ANTS
+    bool
+
+config BR2_PACKAGE_PROVIDES_KUBOS_ISIS_ANTS
+    string
+    default "kubos"

--- a/package/kubos/kubos-isis-ants/kubos-isis-ants
+++ b/package/kubos/kubos-isis-ants/kubos-isis-ants
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+NAME=isis-ants-service
+PROG=/usr/sbin/${NAME}
+PID=/var/run/${NAME}.pid
+
+case "$1" in
+    start)
+    echo "Starting ${NAME}: "
+    start-stop-daemon -S -q -m -b -p ${PID} --exec ${PROG}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    stop)
+    echo "Stopping ${NAME}: "
+    start-stop-daemon -K -q -p ${PID}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    restart)
+    "$0" stop
+    "$0" start
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart}"
+    ;;
+esac
+
+exit $rc

--- a/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
+++ b/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
@@ -1,0 +1,30 @@
+###############################################
+#
+# Kubos ISIS Antenna Systems Service
+#
+###############################################
+
+KUBOS_ISIS_ANTS_POST_BUILD_HOOKS += ISIS_ANTS_BUILD_CMDS
+KUBOS_ISIS_ANTS_POST_INSTALL_TARGET_HOOKS += ISIS_ANTS_INSTALL_TARGET_CMDS
+KUBOS_ISIS_ANTS_POST_INSTALL_TARGET_HOOKS += ISIS_ANTS_INSTALL_INIT_SYSV
+
+define ISIS_ANTS_BUILD_CMDS
+	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/isis-ants-service && \
+	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
+	cargo kubos -c build -t $(KUBOS_TARGET) -- --release
+endef
+
+# Install the application into the rootfs file system
+define ISIS_ANTS_INSTALL_TARGET_CMDS
+	mkdir -p $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -D -m 0755 $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/$(CARGO_OUTPUT_DIR)/isis-ants-service \
+		$(TARGET_DIR)/usr/sbin
+endef
+
+# Install the init script
+define ISIS_ANTS_INSTALL_INIT_SYSV
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_KUBOS_LINUX_PATH)/package/kubos/kubos-isis-ants/kubos-isis-ants \
+	    $(TARGET_DIR)/etc/init.d/S$(BR2_KUBOS_ISIS_ANTS_INIT_LVL)kubos-isis-ants
+endef
+
+$(eval $(virtual-package))


### PR DESCRIPTION
The Kubos service for ISIS antenna systems is finally landing (kubos/kubos#53)

This PR adds the corresponding KLB package and updates the default `config.toml` file with the relevant configuration options.