### PR TITLE
Adding -b flag to app service init

### DIFF
--- a/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service
+++ b/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service
@@ -7,7 +7,7 @@ PID=/var/run/${NAME}.pid
 case "$1" in
     start)
     echo "Starting ${NAME}: "
-    start-stop-daemon -S -q -m -b -p ${PID} --exec ${PROG}
+    start-stop-daemon -q -m -b -p ${PID} --exec ${PROG} -S -- -b
     rc=$?
     if [ $rc -eq 0 ]
     then


### PR DESCRIPTION
Adding `-b` flag to app service initialization call to trigger the `OnBoot` logic for all registered apps