### PR TITLE
Fixing Pumpkin MCU service init script

### DIFF
--- a/package/kubos/kubos-pumpkin-mcu/kubos-pumpkin-mcu
+++ b/package/kubos/kubos-pumpkin-mcu/kubos-pumpkin-mcu
@@ -3,6 +3,6 @@
 # Start the Pumpkin MCU service in the background 
 # passing in the location of the config.toml file 
 # (in the same directory as the service)
-python /usr/sbin/pumpkin-mcu-service/service.py /home/system/etc/config.toml &
+python /usr/sbin/pumpkin-mcu-service/service.py -c /home/system/etc/config.toml &
 
 exit 0


### PR DESCRIPTION
The underlying kubos-service python package was updated to take the configuration file as a command line option rather than a positional argument. Updating the init script to reflect that.
