### PR TITLE
Manually specifying CC for Rust crates

### DIFF
--- a/package/kubos/kubos-clyde-3g-eps/kubos-clyde-3g-eps.mk
+++ b/package/kubos/kubos-clyde-3g-eps/kubos-clyde-3g-eps.mk
@@ -11,7 +11,7 @@ KUBOS_CLYDE_3G_EPS_POST_INSTALL_TARGET_HOOKS += CLYDE_3G_EPS_INSTALL_INIT_SYSV
 define CLYDE_3G_EPS_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/clyde-3g-eps-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	cargo build --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system

--- a/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service.mk
+++ b/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service.mk
@@ -11,7 +11,7 @@ KUBOS_CORE_APP_SERVICE_POST_INSTALL_TARGET_HOOKS += APP_SERVICE_INSTALL_INIT_SYS
 define APP_SERVICE_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/app-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	cargo build --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system

--- a/package/kubos/kubos-core/kubos-core-telemetry-db/kubos-core-telemetry-db.mk
+++ b/package/kubos/kubos-core/kubos-core-telemetry-db/kubos-core-telemetry-db.mk
@@ -11,7 +11,7 @@ KUBOS_CORE_TELEMETRY_DB_POST_INSTALL_TARGET_HOOKS += TELEMETRY_DB_INSTALL_INIT_S
 define TELEMETRY_DB_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/telemetry-service && \
     PATH=$(PATH):~/.cargo/bin && \
-	cargo build --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system

--- a/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
+++ b/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
@@ -11,7 +11,7 @@ KUBOS_ISIS_ANTS_POST_INSTALL_TARGET_HOOKS += ISIS_ANTS_INSTALL_INIT_SYSV
 define ISIS_ANTS_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/isis-ants-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	cargo kubos -c build -t $(KUBOS_TARGET) -- --release
+	CC=$(TARGET_CC) cargo kubos -c build -t $(KUBOS_TARGET) -- --release
 endef
 
 # Install the application into the rootfs file system

--- a/package/kubos/kubos-mai400/kubos-mai400.mk
+++ b/package/kubos/kubos-mai400/kubos-mai400.mk
@@ -11,7 +11,7 @@ KUBOS_MAI400_POST_INSTALL_TARGET_HOOKS += MAI400_INSTALL_INIT_SYSV
 define MAI400_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/mai400-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	cargo build --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system

--- a/package/kubos/kubos-novatel-oem6/kubos-novatel-oem6.mk
+++ b/package/kubos/kubos-novatel-oem6/kubos-novatel-oem6.mk
@@ -11,7 +11,7 @@ KUBOS_NOVATEL_OEM6_POST_INSTALL_TARGET_HOOKS += OEM6_INSTALL_INIT_SYSV
 define OEM6_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/novatel-oem6-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	cargo build --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
 endef
 
 # Install the application into the rootfs file system


### PR DESCRIPTION
We have updated our Rust crates to use Failure v0.1.2. This version of `failure` uses `backtrace`, which uses `backtrace-sys`, which uses `cc`.

The `cc` crate doesn't properly fetch the cross-compiling toolchain. This causes builds to fail for the iOBC target (and magically works for the BBB, but I don't trust it). The solution is to manually specify the location of the gcc. 

This PR adds a CC envar to all of our packages which build Rust crates