### PR TITLE
Adding packages for custom Python modules and monitor service

### DIFF
--- a/common/overlay/home/system/etc/config.toml
+++ b/common/overlay/home/system/etc/config.toml
@@ -58,3 +58,7 @@ wd_timeout = 10
 [file-transfer-service.addr]
 ip = "0.0.0.0"
 port = 8008
+
+[monitor-service.addr]
+ip = "0.0.0.0"
+port = 8009

--- a/package/kubos/Config.in
+++ b/package/kubos/Config.in
@@ -13,7 +13,13 @@ if BR2_PACKAGE_KUBOS
 			Release, tag, or branch of the Kubos repo to use when building Kubos
 			packages
 
+    
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-monitor/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-app-api/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-hal-i2c/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-service-lib/Config.in"
+    
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-clyde-3g-eps/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-isis-ants/Config.in"  	
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-mai400/Config.in"

--- a/package/kubos/kubos-app-api/Config.in
+++ b/package/kubos/kubos-app-api/Config.in
@@ -1,0 +1,10 @@
+config BR2_PACKAGE_KUBOS_APP_API
+    bool "Python App API"
+    default y
+    depends on BR2_PACKAGE_PYTHON
+    select BR2_PACKAGE_PYTHON_TOML
+    help
+        Include the Kubos app API for Python.
+        
+        This API simplifies the process of communicating with Kubos services.
+        It should be included if you intend to write mission applications using Python.

--- a/package/kubos/kubos-app-api/kubos-app-api.mk
+++ b/package/kubos/kubos-app-api/kubos-app-api.mk
@@ -1,0 +1,14 @@
+#####################################################
+#
+# Kubos Python App API Installation
+#
+#####################################################
+KUBOS_APP_API_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
+KUBOS_APP_API_LICENSE = Apache-2.0
+KUBOS_APP_API_LICENSE_FILES = LICENSE
+KUBOS_APP_API_SITE = $(BUILD_DIR)/kubos-$(KUBOS_APP_API_VERSION)/apis/app-api/python
+KUBOS_APP_API_SITE_METHOD = local
+KUBOS_APP_API_SETUP_TYPE = setuptools
+KUBOS_APP_API_DEPENDENCIES = kubos
+
+$(eval $(python-package))

--- a/package/kubos/kubos-hal-i2c/Config.in
+++ b/package/kubos/kubos-hal-i2c/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_KUBOS_HAL_I2C
+    bool "Python I2C HAL"
+    default y
+    depends on BR2_PACKAGE_PYTHON
+    help
+        Include the Kubos I2C HAL for Python.

--- a/package/kubos/kubos-hal-i2c/kubos-hal-i2c.mk
+++ b/package/kubos/kubos-hal-i2c/kubos-hal-i2c.mk
@@ -1,0 +1,14 @@
+#####################################################
+#
+# Kubos Python I2C HAL Installation
+#
+#####################################################
+KUBOS_HAL_I2C_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
+KUBOS_HAL_I2C_LICENSE = Apache-2.0
+KUBOS_HAL_I2C_LICENSE_FILES = LICENSE
+KUBOS_HAL_I2C_SITE = $(BUILD_DIR)/kubos-$(KUBOS_HAL_I2C_VERSION)/hal/python-hal/i2c
+KUBOS_HAL_I2C_SITE_METHOD = local
+KUBOS_HAL_I2C_SETUP_TYPE = setuptools
+KUBOS_HAL_I2C_DEPENDENCIES = kubos
+
+$(eval $(python-package))

--- a/package/kubos/kubos-monitor/Config.in
+++ b/package/kubos/kubos-monitor/Config.in
@@ -1,0 +1,28 @@
+menuconfig BR2_PACKAGE_KUBOS_MONITOR
+    bool "Monitor Service"
+    default y
+    select BR2_PACKAGE_HAS_KUBOS_MONITOR
+    help
+        Include Kubos monitor service.
+        
+        This service provides the ability to query the OBC's current processes and memory usage
+
+if BR2_PACKAGE_KUBOS_MONITOR
+
+config BR2_KUBOS_MONITOR_INIT_LVL
+    int "Monitor Service Init Level"
+    default 90
+    range 10 99
+    depends on BR2_PACKAGE_KUBOS_MONITOR
+    help
+        The initialization priority level of the Kubos service.
+        The lower the number, the earlier the service is initialized.
+
+endif
+
+config BR2_PACKAGE_HAS_KUBOS_MONITOR
+    bool
+
+config BR2_PACKAGE_PROVIDES_KUBOS_MONITOR
+    string
+    default "kubos"

--- a/package/kubos/kubos-monitor/kubos-monitor
+++ b/package/kubos/kubos-monitor/kubos-monitor
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+NAME=monitor-service
+PROG=/usr/sbin/${NAME}
+PID=/var/run/${NAME}.pid
+
+case "$1" in
+    start)
+    echo "Starting ${NAME}: "
+    start-stop-daemon -S -q -m -b -p ${PID} --exec ${PROG}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    stop)
+    echo "Stopping ${NAME}: "
+    start-stop-daemon -K -q -p ${PID}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    restart)
+    "$0" stop
+    "$0" start
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart}"
+    ;;
+esac
+
+exit $rc

--- a/package/kubos/kubos-monitor/kubos-monitor.mk
+++ b/package/kubos/kubos-monitor/kubos-monitor.mk
@@ -1,0 +1,30 @@
+###############################################
+#
+# Kubos Monitor Service
+#
+###############################################
+
+KUBOS_MONITOR_POST_BUILD_HOOKS += MONITOR_BUILD_CMDS
+KUBOS_MONITOR_POST_INSTALL_TARGET_HOOKS += MONITOR_INSTALL_TARGET_CMDS
+KUBOS_MONITOR_POST_INSTALL_TARGET_HOOKS += MONITOR_INSTALL_INIT_SYSV
+
+define MONITOR_BUILD_CMDS
+	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/monitor-service && \
+	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
+	CC=$(TARGET_CC) cargo build --target $(CARGO_TARGET) --release
+endef
+
+# Install the application into the rootfs file system
+define MONITOR_INSTALL_TARGET_CMDS
+	mkdir -p $(TARGET_DIR)/usr/sbin
+	$(INSTALL) -D -m 0755 $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/$(CARGO_OUTPUT_DIR)/monitor-service \
+		$(TARGET_DIR)/usr/sbin
+endef
+
+# Install the init script
+define MONITOR_INSTALL_INIT_SYSV
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_KUBOS_LINUX_PATH)/package/kubos/kubos-monitor/kubos-monitor \
+	    $(TARGET_DIR)/etc/init.d/S$(BR2_KUBOS_MONITOR_INIT_LVL)kubos-monitor
+endef
+
+$(eval $(virtual-package))

--- a/package/kubos/kubos-pumpkin-mcu/Config.in
+++ b/package/kubos/kubos-pumpkin-mcu/Config.in
@@ -3,6 +3,7 @@ menuconfig BR2_PACKAGE_KUBOS_PUMPKIN_MCU
     default n
     depends on BR2_PACKAGE_PYTHON
     select BR2_PACKAGE_PYTHON_GRAPHENE
+    select BR2_PACAKGE_KUBOS_SERVICE_LIB
     help
         Include the Pumpkin MCU Kubos Service.
         

--- a/package/kubos/kubos-service-lib/Config.in
+++ b/package/kubos/kubos-service-lib/Config.in
@@ -1,0 +1,11 @@
+config BR2_PACKAGE_KUBOS_SERVICE_LIB
+    bool "Kubos Service Python Library"
+    default y
+    depends on BR2_PACKAGE_PYTHON
+    select BR2_PACKAGE_PYTHON_GRAPHENE
+    select BR2_PACKAGE_PYTHON_TOML
+    help
+        Include the Kubos service library for Python.
+        
+        This library simplifies the process of writing servives.
+        It should be included if you intend to use services which are written in Python.

--- a/package/kubos/kubos-service-lib/Config.in
+++ b/package/kubos/kubos-service-lib/Config.in
@@ -1,6 +1,6 @@
 config BR2_PACKAGE_KUBOS_SERVICE_LIB
     bool "Kubos Service Python Library"
-    default y
+    default n
     depends on BR2_PACKAGE_PYTHON
     select BR2_PACKAGE_PYTHON_GRAPHENE
     select BR2_PACKAGE_PYTHON_TOML

--- a/package/kubos/kubos-service-lib/kubos-service-lib.mk
+++ b/package/kubos/kubos-service-lib/kubos-service-lib.mk
@@ -1,0 +1,14 @@
+#####################################################
+#
+# Kubos Python Service Library Installation
+#
+#####################################################
+KUBOS_SERVICE_LIB_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
+KUBOS_SERVICE_LIB_LICENSE = Apache-2.0
+KUBOS_SERVICE_LIB_LICENSE_FILES = LICENSE
+KUBOS_SERVICE_LIB_SITE = $(BUILD_DIR)/kubos-$(KUBOS_SERVICE_LIB_VERSION)/libs/kubos-service
+KUBOS_SERVICE_LIB_SITE_METHOD = local
+KUBOS_SERVICE_LIB_SETUP_TYPE = distutils
+KUBOS_SERVICE_LIB_DEPENDENCIES = kubos
+
+$(eval $(python-package))


### PR DESCRIPTION
This PR adds packages for the following items from the kubos repo:

- apis/app-api/python
- hal/python-hal/i2c
- libs/kubos-service
- services/monitor-service

All of the new packages are included by default except for `kubos-service`. That's because there are a couple incompatibilities between its dependencies, buildroot, and CircleCI. These issues may be fixed in the future with [the upgrade to the newer buildroot LTS](https://trello.com/c/Edbd9Rup/29-migrate-to-new-buildroot-lts-version)