### PR TITLE
Adding package for Pumpkin MCU API

### DIFF
--- a/package/kubos/Config.in
+++ b/package/kubos/Config.in
@@ -25,6 +25,7 @@ if BR2_PACKAGE_KUBOS
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-mai400/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-novatel-oem6/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-pumpkin-mcu/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-pumpkin-mcu-api/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-pumpkin-wdt/Config.in"
 
 endif

--- a/package/kubos/kubos-pumpkin-mcu-api/Config.in
+++ b/package/kubos/kubos-pumpkin-mcu-api/Config.in
@@ -1,0 +1,7 @@
+config BR2_PACKAGE_KUBOS_PUMPKIN_MCU_API
+    bool "Pumpkin MCU Python API"
+    default n
+    depends on BR2_PACKAGE_PYTHON
+    help
+        Include the Pumpkin MCU API for Python.
+

--- a/package/kubos/kubos-pumpkin-mcu-api/kubos-pumpkin-mcu-api.mk
+++ b/package/kubos/kubos-pumpkin-mcu-api/kubos-pumpkin-mcu-api.mk
@@ -1,0 +1,14 @@
+#####################################################
+#
+# Kubos Pumpkin MCU Python API Installation
+#
+#####################################################
+KUBOS_PUMPKIN_MCU_API_VERSION = $(call qstrip,$(BR2_KUBOS_VERSION))
+KUBOS_PUMPKIN_MCU_API_LICENSE = Apache-2.0
+KUBOS_PUMPKIN_MCU_API_LICENSE_FILES = LICENSE
+KUBOS_PUMPKIN_MCU_API_SITE = $(BUILD_DIR)/kubos-$(KUBOS_PUMPKIN_MCU_API_VERSION)/apis/pumpkin-mcu-api
+KUBOS_PUMPKIN_MCU_API_SITE_METHOD = local
+KUBOS_PUMPKIN_MCU_API_SETUP_TYPE = setuptools
+KUBOS_PUMPKIN_MCU_API_DEPENDENCIES = kubos
+
+$(eval $(python-package))

--- a/package/kubos/kubos-pumpkin-mcu/Config.in
+++ b/package/kubos/kubos-pumpkin-mcu/Config.in
@@ -3,7 +3,8 @@ menuconfig BR2_PACKAGE_KUBOS_PUMPKIN_MCU
     default n
     depends on BR2_PACKAGE_PYTHON
     select BR2_PACKAGE_PYTHON_GRAPHENE
-    select BR2_PACAKGE_KUBOS_SERVICE_LIB
+    select BR2_PACKAGE_KUBOS_SERVICE_LIB
+    select BR2_PACKAGE_KUBOS_PUMPKIN_MCU_API
     help
         Include the Pumpkin MCU Kubos Service.
         


### PR DESCRIPTION
The Pumpkin MCU service depends on the corresponding MCU API. Adding a new package to get it built into Kubos Linux.

Also fixing a typo...
