### PR TITLE
Updating release test to comply with new file client format

### DIFF
--- a/tools/release-test/run_test.sh
+++ b/tools/release-test/run_test.sh
@@ -45,8 +45,8 @@ CC=/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc cargo build --release --target a
 arm-linux-strip ${BINARY}
 
 # Transfer our test binary to the OBC
-kubos-file-client upload ${BINARY} ${TARGET_DIR}/release-test -r ${1} -p 8008
-kubos-file-client upload manifest.toml ${TARGET_DIR}/manifest.toml -r ${1} -p 8008
+kubos-file-client -r ${1} -p 8008 upload ${BINARY} ${TARGET_DIR}/release-test
+kubos-file-client -r ${1} -p 8008 upload manifest.toml ${TARGET_DIR}/manifest.toml
 
 # Register the app with the applications service
 RESPONSE=$(echo "mutation { register(path: \"${TARGET_DIR}\"){ success, errors, entry { app { uuid } } } }" | nc -uw1 ${1} 8000)
@@ -64,8 +64,8 @@ if ! [[ "${RESPONSE}" =~ "\"success\":true" ]]; then
 fi
 
 # Get our results
-kubos-file-client download ${LOG_FILE} -r ${1} -p 8008
-kubos-file-client download ${TELEM_PATH} -r ${1} -p 8008
+kubos-file-client -r ${1} -p 8008 download ${LOG_FILE}
+kubos-file-client -r ${1} -p 8008 download ${TELEM_PATH}
 tar -xzf ${TELEM_FILE}.tar.gz ${TELEM_FILE}
 
 # Test Cleanup


### PR DESCRIPTION
The file client tweaked the way it checks its arguments. This PR updates the release test to comply with this new ordering