### PR TITLE
Moving BBB/MBM2 U-Boot envars to own partition

### DIFF
--- a/board/kubos/beaglebone-black/genimage.cfg
+++ b/board/kubos/beaglebone-black/genimage.cfg
@@ -28,6 +28,12 @@ image upgrade {
     mountpoint = "/upgrade"
 }
 
+image uboot-envar {
+    ext4 {}
+    size = 2M
+    mountpoint = "/envar"
+}
+
 image kubos-linux.img {
     hdimage {
         disk-signature = 0x4B4C4E58
@@ -43,6 +49,12 @@ image kubos-linux.img {
         partition-type = 0x83
         image = "rootfs.ext4"
         size = 512M
+    }
+        
+    partition envar {
+        partition-type = 0x83
+        image = "uboot-envar"
+        size = 2M
     }
 
     partition user {

--- a/board/kubos/beaglebone-black/overlay/etc/fstab
+++ b/board/kubos/beaglebone-black/overlay/etc/fstab
@@ -6,6 +6,7 @@ tmpfs       /dev/shm    tmpfs   mode=0777   0   0
 tmpfs       /tmp        tmpfs   mode=1777   0   0
 tmpfs       /run        tmpfs   mode=0755,nosuid,nodev  0   0
 sysfs       /sys        sysfs   defaults    0   0
-PARTUUID=4b4c4e58-03  /home           ext4    defaults,noauto        0       2
+PARTUUID=4b4c4e58-03  /envar          ext4    defaults,noauto        0       0
+PARTUUID=4b4c4e58-04  /home           ext4    defaults,noauto        0       2
 PARTUUID=41555820-02  /home/microsd/  ext4    defaults,noauto        0       0
 PARTUUID=41555820-01  /upgrade        ext4    defaults,noauto        0       0

--- a/board/kubos/beaglebone-black/overlay/etc/fw_env.config
+++ b/board/kubos/beaglebone-black/overlay/etc/fw_env.config
@@ -10,4 +10,4 @@
 
 # EXT4
 # MTD device name	    Device offset   Env. size	Flash sector size	Number of sectors
-/home/system/etc/uboot.env  0x0000          0x2800
+/envar/uboot.env  0x0000          0x2800

--- a/board/kubos/beaglebone-black/overlay/etc/inittab
+++ b/board/kubos/beaglebone-black/overlay/etc/inittab
@@ -24,6 +24,7 @@
 ::sysinit:/bin/mount /home
 ::sysinit:/bin/mount /home/microsd
 ::sysinit:/bin/mount /upgrade
+::sysinit:/bin/mount /envar
 # Setup hostname
 ::sysinit:/bin/hostname -F /etc/hostname
 # now run any rc scripts

--- a/board/kubos/pumpkin-mbm2/genimage.cfg
+++ b/board/kubos/pumpkin-mbm2/genimage.cfg
@@ -28,6 +28,12 @@ image upgrade {
     mountpoint = "/upgrade"
 }
 
+image uboot-envar {
+    ext4 {}
+    size = 2M
+    mountpoint = "/envar"
+}
+
 image kubos-linux.img {
     hdimage {
         disk-signature = 0x4B4C4E58
@@ -43,6 +49,12 @@ image kubos-linux.img {
         partition-type = 0x83
         image = "rootfs.ext4"
         size = 512M
+    }
+        
+    partition envar {
+        partition-type = 0x83
+        image = "uboot-envar"
+        size = 2M
     }
 
     partition user {

--- a/board/kubos/pumpkin-mbm2/overlay/etc/fstab
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/fstab
@@ -6,6 +6,7 @@ tmpfs		/dev/shm	tmpfs	mode=0777	0	0
 tmpfs		/tmp		tmpfs	mode=1777	0	0
 tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
 sysfs		/sys		sysfs	defaults	0	0
-PARTUUID=4b4c4e58-03  /home           ext4    defaults,noauto        0       2
+PARTUUID=4b4c4e58-03  /envar          ext4    defaults,noauto        0       0
+PARTUUID=4b4c4e58-04  /home           ext4    defaults,noauto        0       2
 PARTUUID=41555820-02  /home/microsd/  ext4    defaults,noauto        0       0
 PARTUUID=41555820-01  /upgrade        ext4    defaults,noauto        0       0

--- a/board/kubos/pumpkin-mbm2/overlay/etc/fw_env.config
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/fw_env.config
@@ -10,4 +10,4 @@
 
 # EXT4
 # MTD device name	    Device offset   Env. size	Flash sector size	Number of sectors
-/home/system/etc/uboot.env  0x0000          0x2800
+/envar/uboot.env  0x0000          0x2800

--- a/board/kubos/pumpkin-mbm2/overlay/etc/inittab
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/inittab
@@ -24,6 +24,7 @@
 ::sysinit:/bin/mount /home
 ::sysinit:/bin/mount /home/microsd
 ::sysinit:/bin/mount /upgrade
+::sysinit:/bin/mount /envar
 # Setup hostname
 ::sysinit:/bin/hostname -F /etc/hostname
 # now run any rc scripts


### PR DESCRIPTION
**PR Overview**:

Updates the BBB and MBM2 configs to move the U-Boot envars into a new partition in the main Kubos Linux SD image.
The two boards are grouped together in this single PR because the changes are identical.

The `genimage.cfg` changes are what actually creates the new partition.
All other changes are used to mount the new partition for use by the `fw_printenv` and `fw_setenv` commands from the Linux command line

**kubos-linux.img:**

| Partition | Old Contents        | New Contents        |
|-----------|---------------------|---------------------|
| 1         | U-Boot, kernel, DTB | U-Boot, kernel, DTB |
| 2         | RootFS              | RootFS              |
| 3         | User Partition      | U-Boot Envars       |
| 4         | -- Doesn't Exist -- | User Partition      |

The corresponding U-Boot changes are in kubos/uboot#25

**Documentation**:

TODO