### PR TITLE
Explicitly declaring Monit's PID file

### DIFF
--- a/board/kubos/at91sam9g20isis/overlay/etc/monitrc
+++ b/board/kubos/at91sam9g20isis/overlay/etc/monitrc
@@ -4,6 +4,9 @@ SET INIT
 # Run Monit as a background daemon, waking every 60 seconds to perform its process monitoring
 SET DAEMON 60
 
+# Set the PID file the daemon should use so that any user can run `monit status`
+SET PIDFILE /var/run/monit.pid
+
 # Put Monit's statefile into non-persistent storage so that way it will attempt to monitor any
 # services which previously failed too many times after a system reboot
 SET STATEFILE /tmp/monit.state

--- a/board/kubos/beaglebone-black/overlay/etc/monitrc
+++ b/board/kubos/beaglebone-black/overlay/etc/monitrc
@@ -4,6 +4,9 @@ SET INIT
 # Run Monit as a background daemon, waking every 60 seconds to perform its process monitoring
 SET DAEMON 60
 
+# Set the PID file the daemon should use so that any user can run `monit status`
+SET PIDFILE /var/run/monit.pid
+
 # Put Monit's statefile into non-persistent storage so that way it will attempt to monitor any
 # services which previously failed too many times after a system reboot
 SET STATEFILE /tmp/monit.state

--- a/board/kubos/pumpkin-mbm2/overlay/etc/monitrc
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/monitrc
@@ -4,6 +4,9 @@ SET INIT
 # Run Monit as a background daemon, waking every 60 seconds to perform its process monitoring
 SET DAEMON 60
 
+# Set the PID file the daemon should use so that any user can run `monit status`
+SET PIDFILE /var/run/monit.pid
+
 # Put Monit's statefile into non-persistent storage so that way it will attempt to monitor any
 # services which previously failed too many times after a system reboot
 SET STATEFILE /tmp/monit.state


### PR DESCRIPTION
For some reason, when the `kubos` user runs `monit status` it is unable to correctly guess the location of the PID file of the monit daemon to then query the process for its current status information.

This PR manually sets the PID file location (which is just the default location) so that `monit status` can be run from the command line by any user.