### PR TITLE
Check boot corruption

### DIFF
--- a/board/kubos/at91sam9g20isis/overlay/etc/inittab
+++ b/board/kubos/at91sam9g20isis/overlay/etc/inittab
@@ -19,8 +19,8 @@
 ::sysinit:/bin/mkdir -p /dev/pts
 ::sysinit:/bin/mkdir -p /dev/shm
 # Check & clean partitions
-::sysinit:/usr/sbin/fsck -p /dev/root
 ::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p1
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p6
 ::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p7
 ::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p8
 # Mount up partitions with data

--- a/board/kubos/at91sam9g20isis/overlay/etc/inittab
+++ b/board/kubos/at91sam9g20isis/overlay/etc/inittab
@@ -16,9 +16,15 @@
 
 # Startup the system
 ::sysinit:/bin/mount -t proc proc /proc
-::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mkdir -p /dev/pts
 ::sysinit:/bin/mkdir -p /dev/shm
+# Check & clean partitions
+::sysinit:/usr/sbin/fsck -p /dev/root
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p1
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p7
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p8
+# Mount up partitions with data
+::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mount -a
 # Setup hostname
 ::sysinit:/bin/hostname -F /etc/hostname

--- a/board/kubos/beaglebone-black/overlay/etc/inittab
+++ b/board/kubos/beaglebone-black/overlay/etc/inittab
@@ -16,9 +16,16 @@
 
 # Startup the system
 ::sysinit:/bin/mount -t proc proc /proc
-::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mkdir -p /dev/pts
 ::sysinit:/bin/mkdir -p /dev/shm
+# Check & clean partitions
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p1
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p2
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p2
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p3
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p4
+# Mount up partitions with data
+::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mount -a
 # Mount the Kubos directories which use partuuid
 ::sysinit:/bin/mount /home

--- a/board/kubos/pumpkin-mbm2/overlay/etc/inittab
+++ b/board/kubos/pumpkin-mbm2/overlay/etc/inittab
@@ -16,9 +16,16 @@
 
 # Startup the system
 ::sysinit:/bin/mount -t proc proc /proc
-::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mkdir -p /dev/pts
 ::sysinit:/bin/mkdir -p /dev/shm
+# Check & clean partitions
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p1
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk0p2
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p2
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p3
+::sysinit:/usr/sbin/fsck -p /dev/mmcblk1p4
+# Mount up partitions with data
+::sysinit:/bin/mount -o remount,rw /
 ::sysinit:/bin/mount -a
 # Mount the Kubos directories which use partuuid
 ::sysinit:/bin/mount /home

--- a/common/overlay/etc/init.d/S99kubos-verify
+++ b/common/overlay/etc/init.d/S99kubos-verify
@@ -20,6 +20,7 @@
 # Update the U-Boot variables to indicate that we have successfully booted
 fw_setenv kubos_curr_tried 0
 fw_setenv bootcount 0
+sync
 
 # Make sure the default user's home directory exists
 mkdir -p /home/kubos


### PR DESCRIPTION
**PR Overview**:

 - Add `sync` after changing boot count
-  Run `fsck` against writeable partitions during boot

**Documentation**:

  1. No documentation changes are needed

**Integration Tests**:
