### PR TITLE
Removing app UUID from release test

### DIFF
--- a/tools/release-test/src/app_service.rs
+++ b/tools/release-test/src/app_service.rs
@@ -39,7 +39,6 @@ fn get_apps() -> Result<(), Error> {
         apps {
             active,
             app {
-                uuid,
                 name,
                 version,
                 author


### PR DESCRIPTION
UUIDs were removed from the app service with kubos/kubos#305

Updating the release test to be compatible with the new format