### PR TITLE
move buildroot + uboot dependency info into tools/deps.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,13 @@ jobs:
       working_directory: ~/project/kubos-linux-build
       steps:
         - checkout
-        - run: ./build.sh | tee full_build.log
+        - run: ./tools/build-ci.sh | tee full_build.log
         - store_artifacts:
             path: full_build.log
             destination: Beaglebone-Black/full_build.log
         - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/kubos-linux.tar.gz
-            destination: Beaglebone-Black/kubos-linux.tar.gz
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/aux-sd.tar.gz
-            destination: Beaglebone-Black/aux-sd.tar.gz
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/kpack-base.itb
-            destination: Beaglebone-Black/kpack-base.itb
+            path: output/beaglebone-black
+            destination: Beaglebone-Black
     build_mbm2:
       docker:
         - image: kubos/kubos-linux-dev:latest
@@ -29,19 +23,14 @@ jobs:
       working_directory: ~/project/kubos-linux-build
       steps:
         - checkout
-        - run: ./build.sh | tee full_build.log
+        - load_deps
+        - run: ./tools/build-ci.sh | tee full_build.log
         - store_artifacts:
             path: full_build.log
             destination: Pumpkin-MBM2/full_build.log
         - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/kubos-linux.tar.gz
-            destination: Pumpkin-MBM2/kubos-linux.tar.gz
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/aux-sd.tar.gz
-            destination: Pumpkin-MBM2/aux-sd.tar.gz
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/kpack-base.itb
-            destination: Pumpkin-MBM2/kpack-base.itb
+            path: output/pumpkin-mbm2
+            destination: Pumpkin-MBM2
     build_iobc:
       docker:
         - image: kubos/kubos-linux-dev:latest
@@ -50,19 +39,13 @@ jobs:
       working_directory: ~/project/kubos-linux-build
       steps:
         - checkout
-        - run: ./build.sh | tee full_build.log
+        - run: ./tools/build-ci.sh | tee full_build.log
         - store_artifacts:
             path: full_build.log
             destination: iOBC/full_build.log
         - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/kubos-linux.tar.gz
-            destination: iOBC/kubos-linux.tar.gz
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/at91sam9g20isis.dtb
-            destination: iOBC/at91sam9g20isis.dtb
-        - store_artifacts:
-            path: ../buildroot-2019.02.2/output/images/u-boot.bin
-            destination: iOBC/u-boot.bin
+            path: output/at91sam9g20isis
+            destination: iOBC
             
 workflows:
   version: 2

--- a/build.sh
+++ b/build.sh
@@ -2,30 +2,23 @@
 
 set -e -o pipefail
 
-buildroot_tar="buildroot-2019.02.2.tar.gz"
-buildroot_url="https://buildroot.uclibc.org/downloads/$buildroot_tar"
+klb_dir=$(cd `dirname "$0"`; pwd)
+. "$klb_dir/tools/deps.sh"
 
-board="$KUBOS_BOARD"
+# cd out of the kubos-linux-build directory
+cd "$klb_dir/.."
 
-latest_tag=`git tag --sort=-creatordate | head -n 1`
-sed -i "s/0.0.0/$latest_tag/g" common/linux-kubos.config
+echo "Getting Buildroot $buildroot_version"
 
-echo "Building $latest_tag for Board: $board"
+wget "$buildroot_url" && tar xzf "$buildroot_tar" && rm "$buildroot_tar"
 
-cd .. #cd out of the kubos-linux-build directory
+cd "$buildroot_dir_abs"
 
-echo "Getting Buildroot"
-
-wget $buildroot_url && tar xzf $buildroot_tar && rm $buildroot_tar
-
-cd ./buildroot*
-
-make BR2_EXTERNAL=../kubos-linux-build ${board}_defconfig
+echo "Configuring Buildroot for $klb_board"
+make BR2_EXTERNAL=$klb_dir ${klb_board}_defconfig
 
 echo "Removing old toolchains"
-
 rm /usr/bin/*_toolchain -R
 
-echo "Starting Build"
-
+echo "Building KubOS $klb_latest_tag"
 make

--- a/tools/build-ci.sh
+++ b/tools/build-ci.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+klb_dir=$(cd `dirname "$0"/..`; pwd)
+. "$klb_dir/tools/deps.sh"
+
+klb_out_dir=output/$klb_board
+buildroot_out_dir=$buildroot_dir_abs/output
+
+echo "Tagging KubOS $klb_latest_tag"
+sed -i "s/0.0.0/$klb_latest_tag/g" "$klb_dir/common/linux-kubos.config"
+
+
+$klb_dir/build.sh
+
+if [[ ! -d "$klb_out_dir" ]]; then
+    mkdir -p "$klb_out_dir"
+fi
+
+
+echo "Build successful, copying images to $klb_out_dir"
+
+case "$klb_board" in
+    pumpkin-mbm2|beaglebone-black)
+        cp $buildroot_out_dir/images/kubos-linux.tar.gz  \
+           $buildroot_out_dir/images/aux-sd.tar.gz \
+           $buildroot_out_dir/images/kpack-base.itb \
+           $klb_out_dir
+        ;;
+    at91sam9g20isis)
+        cp $buildroot_out_dir/images/kubos-linux.tar.gz  \
+           $buildroot_out_dir/images/at91sam9g20isis.dtb \
+           $buildroot_out_dir/images/u-boot.bin \
+           $klb_out_dir
+        ;;
+esac
+
+echo "Done"

--- a/tools/deps.sh
+++ b/tools/deps.sh
@@ -1,0 +1,22 @@
+# Common versions and dependency information for use by other shell scripts in KLB
+#
+# Requires $klb_dir to be set to the top level kubos-linux-build directory. Example:
+#         klb_dir=$(cd `dirname "$0"`; pwd)
+#         . "$klb_dir/tools/deps.sh"
+#
+#         echo $buildroot_version
+#         echo $uboot_branch
+#
+# Note this script is intended to be consumed by other executables, and is not useful on it's own
+
+klb_latest_tag=`git tag --sort=-creatordate | head -n 1`
+klb_board="${KUBOS_BOARD:-beaglebone-black}"
+
+buildroot_version="2019.02.3"
+buildroot_dirname="buildroot-$buildroot_version"
+buildroot_tar="$buildroot_dirname.tar.gz"
+buildroot_url="https://buildroot.uclibc.org/downloads/$buildroot_tar"
+buildroot_dir_abs=$(dirname "$klb_dir")/buildroot-$buildroot_version
+
+uboot_branch="1.1"
+uboot_branch_iobc="1.0"

--- a/tools/format-image.sh
+++ b/tools/format-image.sh
@@ -28,10 +28,12 @@
 #  * s - Size, in MB, of SD card (default 3800)
 #  * t {target} - target device to build image for
 #
- 
+klb_dir=$(cd `dirname "$0"`/..; pwd)
+. "$klb_dir/tools/deps.sh"
+
 device=""
 image=kubos-linux.img
-branch=1.0
+branch=$uboot_branch_iobc
 package=0
 size=3800
 output=output
@@ -69,7 +71,7 @@ do
       	  ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2019.02.2/${output}}
+: ${BASE_DIR:=../../$buildroot_dirname/${output}}
 
 if [ "${package}" -gt "1" ] && [ ! ${rflag} ]; then
     echo "-t target must be specified in order to build kernel" >&2

--- a/tools/format-sd.sh
+++ b/tools/format-sd.sh
@@ -28,7 +28,10 @@
 #
 
 set -e
- 
+
+klb_dir=$(cd `dirname "$0"`/..; pwd)
+. "$klb_dir/tools/deps.sh"
+
 device=/dev/sdb
 branch=master
 wipe=false
@@ -60,7 +63,7 @@ do
       	  ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2019.02.2/output}
+: ${BASE_DIR:=../../$buildroot_dirname/output}
 
 if ${wipe}; then
   echo '\nWiping SD card. This may take a while...'

--- a/tools/kpack-NOR.its
+++ b/tools/kpack-NOR.its
@@ -25,7 +25,7 @@
 
 	images {
 		dtb@1 {
-			data = /incbin/("./../../buildroot-2019.02.2/output/images/at91sam9g20isis.dtb");
+			data = /incbin/("./images/at91sam9g20isis.dtb");
 			type = "firmware";
 			arch = "arm";
 			os = "linux";

--- a/tools/kubos-kernel.sh
+++ b/tools/kubos-kernel.sh
@@ -16,9 +16,11 @@
 #
 # kubos-package: Create Kubos Linux Upgrade Package (kpack)
 #
- 
+klb_dir=$(cd `dirname "$0"`/..; pwd)
+. "$klb_dir/tools/deps.sh"
+
 input=kubos-kernel.its
-branch=1.0
+branch=$uboot_branch_iobc
 output=output
 
 # Process command arguments
@@ -40,7 +42,7 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2019.02.2/${output}}
+: ${BASE_DIR:=../../$buildroot_dirname/${output}}
 
 # Build the package
 ${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kubos-kernel.itb

--- a/tools/kubos-nor-package.sh
+++ b/tools/kubos-nor-package.sh
@@ -16,10 +16,13 @@
 #
 # kubos-package: Create Kubos Linux Upgrade Package (kpack)
 #
- 
+
+klb_dir=$(cd `dirname "$0"`/..; pwd)
+. "$klb_dir/tools/deps.sh"
+
 version=$(date +%Y.%m.%d)
 input=kpack-NOR.its
-branch=1.0
+branch=$uboot_branch_iobc
 
 # Process command arguments
 
@@ -40,9 +43,24 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2019.02.2/output}
+: ${BASE_DIR:=../../$buildroot_dirname/output}
 
-# Build the package
-${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${input} kpack-nor-${version}.itb
+rootfs_dir=${BASE_DIR}/images
+
+if [[ ! -d "$rootfs_dir" ]]; then
+    echo "Buildroot images dir doesn't exist: $rootfs_dir"
+    exit 1
+fi
+
+# copy the package its ile
+cp ${input} ${rootfs_dir}/
+input_name=$(basename ${input})
+
+# Build the package relative to buildroot
+out_dir=$PWD
+
+pushd ${rootfs_dir}
+${BASE_DIR}/build/uboot-${branch}/tools/mkimage -f ${rootfs_dir}/${input_name} "${out_dir}/kpack-nor-${version}.itb"
+popd
 
 

--- a/tools/kubos-package.sh
+++ b/tools/kubos-package.sh
@@ -16,10 +16,13 @@
 #
 # kubos-package: Create Kubos Linux Upgrade Package (kpack)
 #
- 
+
+klb_dir=$(cd `dirname "$0"`/..; pwd)
+. "$klb_dir/tools/deps.sh"
+
 version=$(date +%Y.%m.%d)
 input=kpack.its
-branch=1.1
+branch=$uboot_branch
 rflag=false
 output=output
 
@@ -58,7 +61,7 @@ do
 	    ;;
     esac
 done
-: ${BASE_DIR:=../../buildroot-2019.02.2/${output}}
+: ${BASE_DIR:=../../$buildroot_dirname/${output}}
 
 if ! ${rflag}
 then


### PR DESCRIPTION
**PR Overview**:

Many of the build and package tools for KLB have hard coded the buildroot and uboot dependency info, making the upgrade process brittle.

This PR makes it easy to change our dependency on these packages in one central location (`tools/deps.sh`)

**Documentation**:

No docs yet outside of code. I want to get feedback on the idea first, if you like it then I'll add user documentation.


**Integration Tests**:

-  I tested generating an image for the ISIS iOBC but need to flash/test the actual image to make sure I didn't mess anything up. Do we have integration tests for the scripts under `tools`? 
