### PR TITLE
Updating release test for file transfer downlink & gen service config

### DIFF
--- a/tools/release-test/README.rst
+++ b/tools/release-test/README.rst
@@ -8,6 +8,14 @@ Pre-Requisites
 --------------
 
 - Load the release candidate onto an OBC which has an ethernet connection
+- Update the OBC's service config file to add the file transfer service downlink information, then
+  start the file transfer service::
+
+    [file-transfer-service]
+    storage_dir = "/home/system/file-storage"
+    downlink_ip = "{host IP}"
+    downlink_port = 8080
+    
 - Script must be run from this directory from within an instance of the Kubos SDK
 
 .. note::

--- a/tools/release-test/run_test.sh
+++ b/tools/release-test/run_test.sh
@@ -48,8 +48,8 @@ PKG_CONFIG_ALLOW_CROSS=1 CC=/usr/bin/bbb_toolchain/usr/bin/arm-linux-gcc cargo b
 arm-linux-strip ${BINARY}
 
 # Transfer our test binary to the OBC
-kubos-file-client -r ${1} -p 8008 upload ${BINARY} ${TARGET_DIR}/release-test
-kubos-file-client -r ${1} -p 8008 upload manifest.toml ${TARGET_DIR}/manifest.toml
+kubos-file-client -r ${1} -p 8008 -P 8080 upload ${BINARY} ${TARGET_DIR}/release-test
+kubos-file-client -r ${1} -p 8008 -P 8080 upload manifest.toml ${TARGET_DIR}/manifest.toml
 
 # Register the app with the applications service
 RESPONSE=$(curl ${1}:8000 -H "Content-Type: application/json" --data "{\"query\":\"mutation { register(path: \\\"${TARGET_DIR}\\\"){ success, errors } }\"}")
@@ -67,8 +67,8 @@ fi
 sleep 1
 
 # Get our results
-kubos-file-client -r ${1} -p 8008 download ${LOG_FILE} test-output
-kubos-file-client -r ${1} -p 8008 download ${TELEM_PATH}
+kubos-file-client -r ${1} -p 8008 -P 8080 download ${LOG_FILE} test-output
+kubos-file-client -r ${1} -p 8008 -P 8080 download ${TELEM_PATH}
 tar -xzf ${TELEM_FILE}.tar.gz ${TELEM_FILE}
 
 # Test Cleanup

--- a/tools/release-test/src/app_service.rs
+++ b/tools/release-test/src/app_service.rs
@@ -47,7 +47,7 @@ fn get_apps() -> Result<(), Error> {
     }"#;
 
     match query(
-        &ServiceConfig::new("app-service"),
+        &ServiceConfig::new("app-service")?,
         request,
         Some(Duration::from_secs(1)),
     ) {

--- a/tools/release-test/src/monitor_service.rs
+++ b/tools/release-test/src/monitor_service.rs
@@ -41,7 +41,7 @@ fn get_mem() -> Result<(), Error> {
     let request = "{memInfo{available, total, free, lowFree}}";
 
     let response = match query(
-        &ServiceConfig::new("monitor-service"),
+        &ServiceConfig::new("monitor-service")?,
         request,
         Some(Duration::from_secs(1)),
     ) {
@@ -86,7 +86,7 @@ fn get_ps() -> Result<(), Error> {
     }"#;
 
     match query(
-        &ServiceConfig::new("monitor-service"),
+        &ServiceConfig::new("monitor-service")?,
         request,
         Some(Duration::from_secs(1)),
     ) {

--- a/tools/release-test/src/telem_service.rs
+++ b/tools/release-test/src/telem_service.rs
@@ -58,7 +58,7 @@ pub fn insert() -> Result<(), Error> {
     "#;
 
     match query(
-        &ServiceConfig::new("telemetry-service"),
+        &ServiceConfig::new("telemetry-service")?,
         &request,
         Some(Duration::from_secs(1)),
     ) {
@@ -102,7 +102,7 @@ pub fn normal_query() -> Result<(), Error> {
     }"#;
 
     match query(
-        &ServiceConfig::new("telemetry-service"),
+        &ServiceConfig::new("telemetry-service")?,
         request,
         Some(Duration::from_secs(1)),
     ) {
@@ -125,7 +125,7 @@ pub fn routed_query() -> Result<(), Error> {
     );
 
     match query(
-        &ServiceConfig::new("telemetry-service"),
+        &ServiceConfig::new("telemetry-service")?,
         &request,
         Some(Duration::from_secs(1)),
     ) {
@@ -152,7 +152,7 @@ pub fn delete() -> Result<(), Error> {
     "#;
 
     match query(
-        &ServiceConfig::new("telemetry-service"),
+        &ServiceConfig::new("telemetry-service")?,
         request,
         Some(Duration::from_secs(1)),
     ) {


### PR DESCRIPTION
This PR updates the release test in response to two changes we have made:

- kubos/kubos#372 - The file transfer service now requires that the downlink IP and port be defined
- kubos/kubos#431 - Service config initialization now returns a `Result`, failing when errors are encountered instead of taking default values