### PR TITLE
Fixing CONFIG_LOCALVERSION for MBM2

### DIFF
--- a/common/linux-kubos.config
+++ b/common/linux-kubos.config
@@ -1,3 +1,4 @@
+# Linux configuration settings common to all KubOS target boards
 CONFIG_LOCALVERSION="-KubOS-0.0.0"
 # CONFIG_LOCALVERSION_AUTO is not set
 CONFIG_KERNEL_LZ4=y


### PR DESCRIPTION
For *some* reason, when Buildroot goes to create the Linux configuration file for the MBM2 by combing the common linux config and the mbm2-specific config, the `CONFIG_LOCALVERSION` value gets set to `""` instead of `"-KubOS-0.0.0"`. I was unable to figure out how long this has been an issue for, but it goes back to atleast v1.10.
This problem *does not* occur for the BBB, which has an almost identical configuration :/

I fixed the issue by adding a comment line to the top of the common config file. It does not functionally change anything. But is completely necessary, apparently.