### PR TITLE
Updating app service query

### DIFF
--- a/tools/release-test/src/app_service.rs
+++ b/tools/release-test/src/app_service.rs
@@ -36,13 +36,20 @@ fn get_apps() -> Result<(), Error> {
     info!("Querying for active applications");
 
     let request = r#"{
-        apps {
+        registeredApps {
             active,
             app {
                 name,
                 version,
                 author
             }
+        },
+        appStatus {
+            name,
+            version,
+            runLevel,
+            startTime,
+            running
         }
     }"#;
 


### PR DESCRIPTION
The app service schema changed with kubos/kubos#445

Updating the release test to use the new query name and add an app monitoring query