### PR TITLE
Adding scheduler package

### DIFF
--- a/package/kubos/kubos-core/Config.in
+++ b/package/kubos/kubos-core/Config.in
@@ -3,6 +3,7 @@ menuconfig BR2_PACKAGE_KUBOS_CORE
    default y
    select BR2_PACKAGE_KUBOS_CORE_APP_SERVICE
    select BR2_PACKAGE_KUBOS_CORE_FILE_TRANSFER
+   select BR2_PACKAGE_KUBOS_CORE_SCHEDULER
    select BR2_PACKAGE_KUBOS_CORE_SHELL
    select BR2_PACKAGE_KUBOS_CORE_TELEMETRY_DB
    help
@@ -11,6 +12,7 @@ menuconfig BR2_PACKAGE_KUBOS_CORE
 if BR2_PACKAGE_KUBOS_CORE
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-app-service/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-file-transfer/Config.in"
+    source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-scheduler/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-shell/Config.in"
     source "$BR2_EXTERNAL_KUBOS_LINUX_PATH/package/kubos/kubos-core/kubos-core-telemetry-db/Config.in"
 endif

--- a/package/kubos/kubos-core/kubos-core-scheduler/Config.in
+++ b/package/kubos/kubos-core/kubos-core-scheduler/Config.in
@@ -1,0 +1,68 @@
+menuconfig BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    bool "Scheduler Service"
+    default n
+    select BR2_PACKAGE_HAS_KUBOS_CORE_SCHEDULER
+    help
+        Include Kubos application service.
+
+if BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+
+config BR2_KUBOS_CORE_SCHEDULER_INIT_LVL
+    int "Scheduler Service Init Level"
+    default 99
+    range 10 99
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    help
+        The initialization priority level of the Kubos application service.
+        The lower the number, the earlier the service is initialized.
+
+config BR2_KUBOS_CORE_SCHEDULER_RESTART_COUNT
+    int "Scheduler Service Restart Limit"
+    default 3
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    depends on BR2_PACKAGE_MONIT
+    help
+        The maximum number of times the service should be restarted within the timeframe
+        specified by BR2_KUBOS_CORE_SCHEDULER_RESTART_CYCLES if it goes down
+
+config BR2_KUBOS_CORE_SCHEDULER_RESTART_CYCLES
+    int "Scheduler Service Restart Limit Timeframe"
+    default 10
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    depends on BR2_PACKAGE_MONIT
+    help
+        The number of Monit monitoring cycles in which the maximum number of service restarts
+        must occur before the system stops trying to recover the service.
+        
+        The resulting maximum timeframe in which the restarts must occur can be calculated by
+        multiplying this number by the length of a single Monit sleep cycle (60 seconds)
+
+config BR2_KUBOS_CORE_SCHEDULER_IP
+    string "Scheduler Service IP Address"
+    default "0.0.0.0"
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    help
+        The IP address which the scheduler service should use to receive GraphQL requests
+        
+config BR2_KUBOS_CORE_SCHEDULER_PORT
+    int "Scheduler Service Port"
+    default 8010
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    help
+        The port which the scheduler service should use to receive GraphQL requests
+
+config BR2_KUBOS_CORE_SCHEDULER_REGISTRY
+    string "Scheduler Service Storage Directory"
+    default "/home/system/kubos/schedules"
+    depends on BR2_PACKAGE_KUBOS_CORE_SCHEDULER
+    help
+        The directory which the scheduler service should use to store all registry entries
+
+endif
+
+config BR2_PACKAGE_HAS_KUBOS_CORE_SCHEDULER
+    bool
+
+config BR2_PACKAGE_PROVIDES_KUBOS_CORE_SCHEDULER
+    string
+    default "kubos"

--- a/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler
+++ b/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+NAME=scheduler-service
+PROG=/usr/sbin/${NAME}
+PID=/var/run/${NAME}.pid
+
+case "$1" in
+    start)
+    echo "Starting ${NAME}: "
+    start-stop-daemon -q -m -b -p ${PID} --exec ${PROG} -S -- -b
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    stop)
+    echo "Stopping ${NAME}: "
+    start-stop-daemon -K -q -p ${PID}
+    rc=$?
+    if [ $rc -eq 0 ]
+    then
+        echo "OK"
+    else
+        echo "FAIL" >&2
+    fi
+    ;;
+    restart)
+    "$0" stop
+    "$0" start
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart}"
+    ;;
+esac
+
+exit $rc

--- a/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler.mk
+++ b/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler.mk
@@ -1,0 +1,53 @@
+###############################################
+#
+# Kubos Application Service
+#
+###############################################
+
+KUBOS_CORE_SCHEDULER_POST_BUILD_HOOKS += SCHEDULER_BUILD_CMDS
+KUBOS_CORE_SCHEDULER_INSTALL_STAGING = YES
+KUBOS_CORE_SCHEDULER_POST_INSTALL_STAGING_HOOKS += SCHEDULER_INSTALL_STAGING_CMDS
+KUBOS_CORE_SCHEDULER_POST_INSTALL_TARGET_HOOKS += SCHEDULER_INSTALL_TARGET_CMDS
+KUBOS_CORE_SCHEDULER_POST_INSTALL_TARGET_HOOKS += SCHEDULER_INSTALL_INIT_SYSV
+
+define SCHEDULER_BUILD_CMDS
+	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/scheduler-service && \
+	PATH=$(PATH):~/.cargo/bin && \
+	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) cargo build --package scheduler-service --target $(CARGO_TARGET) --release
+endef
+
+# Generate the config settings for the service and add them to a fragment file
+define SCHEDULER_INSTALL_STAGING_CMDS
+	echo '[scheduler-service.addr]' > $(KUBOS_CONFIG_FRAGMENT_DIR)/scheduler-service
+	echo 'ip = ${BR2_KUBOS_CORE_SCHEDULER_IP}' >> $(KUBOS_CONFIG_FRAGMENT_DIR)/scheduler-service
+	echo -e 'port = ${BR2_KUBOS_CORE_SCHEDULER_PORT}\n' >> $(KUBOS_CONFIG_FRAGMENT_DIR)/scheduler-service
+	echo '[scheduler-service]' >> $(KUBOS_CONFIG_FRAGMENT_DIR)/scheduler-service
+	echo -e 'schedules_dir = ${BR2_KUBOS_CORE_SCHEDULER_REGISTRY}\n' >> $(KUBOS_CONFIG_FRAGMENT_DIR)/scheduler-service
+endef
+
+# Install the application into the rootfs file system
+define SCHEDULER_INSTALL_TARGET_CMDS
+	mkdir -p $(TARGET_DIR)/usr/sbin
+	PATH=$(PATH):~/.cargo/bin:$(HOST_DIR)/usr/bin && \
+	arm-linux-strip $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/$(CARGO_OUTPUT_DIR)/scheduler-service
+	$(INSTALL) -D -m 0755 $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/$(CARGO_OUTPUT_DIR)/scheduler-service \
+		$(TARGET_DIR)/usr/sbin
+
+	echo 'CHECK PROCESS scheduler-service PIDFILE /var/run/scheduler-service.pid' > $(TARGET_DIR)/etc/monit.d/scheduler-service.cfg
+	echo '	START PROGRAM = "/etc/init.d/S${BR2_KUBOS_CORE_SCHEDULER_INIT_LVL}kubos-core-scheduler start"' >> $(TARGET_DIR)/etc/monit.d/scheduler-service.cfg 
+	echo '	IF ${BR2_KUBOS_CORE_SCHEDULER_RESTART_COUNT} RESTART WITHIN ${BR2_KUBOS_CORE_SCHEDULER_RESTART_CYCLES} CYCLES THEN TIMEOUT' \
+	>> $(TARGET_DIR)/etc/monit.d/scheduler-service.cfg  
+endef
+
+# Install the init script
+define SCHEDULER_INSTALL_INIT_SYSV
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_KUBOS_LINUX_PATH)/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler \
+		$(TARGET_DIR)/etc/init.d/S$(BR2_KUBOS_CORE_SCHEDULER_INIT_LVL)kubos-core-scheduler
+endef
+
+kubos-core-scheduler-cargoclean: kubos-core-scheduler-service-dirclean
+	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/scheduler-service && \
+	PATH=$(PATH):~/.cargo/bin && \
+	cargo clean
+
+$(eval $(virtual-package))


### PR DESCRIPTION
CI will fail until kubos/kubos#443 has been merged.

If CI continues to fail afterwards, check out the `BR_COMPILER_PARANOID_UNSAFE_PATH` option. (It somehow got turned on in my test build. It's possible I did that on purpose when poking around at some point, but I don't remember)

**NOTE**: The default ``schedules_dir`` value is currently different than what is documented. I set it this way to better match the app and telemetry services. Maybe change this value before finally merging