### PR TITLE
Fix link to Kubos Linux documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Check out the official [Kubos Linux](https://docs.kubos.com/latest/os-docs/linux-docs/index.html) documentation for the most current instructions on how to setup and interact with Kubos Linux on specific boards. 
+Check out the official [Kubos Linux](https://docs.kubos.com/latest/ecosystem/index.html#kubos-linux) documentation for the most current instructions on how to setup and interact with Kubos Linux on specific boards. 
 Kubos uses BuildRoot as its main Linux build tool.  This repo contains the configuration and patch files required by BuildRoot to build Linux for each of the OBCs that Kubos supports.
 
 ## Contributing


### PR DESCRIPTION
**PR Overview**:

- Description of what this PR is for and high-level overview of what was changed

The link to the Kubos Linux documentation in the README file is broken for versions >1.15.
This commit changes the target url to the new location inside the web documentation.

**Documentation**:

Only documentation changes
