### PR TITLE
Allow rust packages to find the linker correctly

### DIFF
--- a/package/kubos/kubos-clyde-3g-eps/kubos-clyde-3g-eps.mk
+++ b/package/kubos/kubos-clyde-3g-eps/kubos-clyde-3g-eps.mk
@@ -13,7 +13,7 @@ KUBOS_CLYDE_3G_EPS_POST_INSTALL_TARGET_HOOKS += CLYDE_3G_EPS_INSTALL_INIT_SYSV
 define CLYDE_3G_EPS_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/clyde-3g-eps-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	CC=$(TARGET_CC) cargo build --package clyde-3g-eps-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package clyde-3g-eps-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service.mk
+++ b/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service.mk
@@ -13,7 +13,7 @@ KUBOS_CORE_APP_SERVICE_POST_INSTALL_TARGET_HOOKS += APP_SERVICE_INSTALL_INIT_SYS
 define APP_SERVICE_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/app-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) cargo build --package kubos-app-service --target $(CARGO_TARGET) --release
+	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package kubos-app-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-core/kubos-core-file-transfer/kubos-core-file-transfer.mk
+++ b/package/kubos/kubos-core/kubos-core-file-transfer/kubos-core-file-transfer.mk
@@ -13,7 +13,7 @@ KUBOS_CORE_FILE_TRANSFER_POST_INSTALL_TARGET_HOOKS += FILE_TRANSFER_INSTALL_INIT
 define FILE_TRANSFER_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/file-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	CC=$(TARGET_CC) cargo build --package file-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package file-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler.mk
+++ b/package/kubos/kubos-core/kubos-core-scheduler/kubos-core-scheduler.mk
@@ -13,7 +13,7 @@ KUBOS_CORE_SCHEDULER_POST_INSTALL_TARGET_HOOKS += SCHEDULER_INSTALL_INIT_SYSV
 define SCHEDULER_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/scheduler-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) cargo build --package scheduler-service --target $(CARGO_TARGET) --release
+	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package scheduler-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-core/kubos-core-shell/kubos-core-shell.mk
+++ b/package/kubos/kubos-core/kubos-core-shell/kubos-core-shell.mk
@@ -13,7 +13,7 @@ KUBOS_CORE_SHELL_POST_INSTALL_TARGET_HOOKS += SHELL_INSTALL_INIT_SYSV
 define SHELL_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/shell-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	CC=$(TARGET_CC) cargo build --package shell-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package shell-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-core/kubos-core-telemetry-db/kubos-core-telemetry-db.mk
+++ b/package/kubos/kubos-core/kubos-core-telemetry-db/kubos-core-telemetry-db.mk
@@ -13,7 +13,7 @@ KUBOS_CORE_TELEMETRY_DB_POST_INSTALL_TARGET_HOOKS += TELEMETRY_DB_INSTALL_INIT_S
 define TELEMETRY_DB_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/telemetry-service && \
 	PATH=$(PATH):~/.cargo/bin && \
-	CC=$(TARGET_CC) cargo build --package telemetry-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package telemetry-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
+++ b/package/kubos/kubos-isis-ants/kubos-isis-ants.mk
@@ -13,7 +13,7 @@ KUBOS_ISIS_ANTS_POST_INSTALL_TARGET_HOOKS += ISIS_ANTS_INSTALL_INIT_SYSV
 define ISIS_ANTS_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/isis-ants-service && \
 	PATH=$(PATH):~/.cargo/bin:$(HOST_DIR)/usr/bin && \
-	CC=$(TARGET_CC) CXX=$(TARGET_CXX) cargo kubos -c build -t $(KUBOS_TARGET) -- --release --package isis-ants-service
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" CXX=$(TARGET_CXX) cargo kubos -c build -t $(KUBOS_TARGET) -- --release --package isis-ants-service
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-mai400/kubos-mai400.mk
+++ b/package/kubos/kubos-mai400/kubos-mai400.mk
@@ -13,7 +13,7 @@ KUBOS_MAI400_POST_INSTALL_TARGET_HOOKS += MAI400_INSTALL_INIT_SYSV
 define MAI400_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/mai400-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	CC=$(TARGET_CC) cargo build --package mai400-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package mai400-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-monitor/kubos-monitor.mk
+++ b/package/kubos/kubos-monitor/kubos-monitor.mk
@@ -13,7 +13,7 @@ KUBOS_MONITOR_POST_INSTALL_TARGET_HOOKS += MONITOR_INSTALL_INIT_SYSV
 define MONITOR_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/monitor-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	CC=$(TARGET_CC) cargo build --package monitor-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package monitor-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-novatel-oem6/kubos-novatel-oem6.mk
+++ b/package/kubos/kubos-novatel-oem6/kubos-novatel-oem6.mk
@@ -13,7 +13,7 @@ KUBOS_NOVATEL_OEM6_POST_INSTALL_TARGET_HOOKS += OEM6_INSTALL_INIT_SYSV
 define OEM6_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/novatel-oem6-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	CC=$(TARGET_CC) cargo build --package novatel-oem6-service --target $(CARGO_TARGET) --release
+	CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package novatel-oem6-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file

--- a/package/kubos/kubos-nsl-duplex/kubos-nsl-duplex.mk
+++ b/package/kubos/kubos-nsl-duplex/kubos-nsl-duplex.mk
@@ -15,7 +15,7 @@ KUBOS_NSL_DUPLEX_POST_INSTALL_TARGET_HOOKS += NSL_DUPLEX_INSTALL_INIT_SYSV
 define NSL_DUPLEX_BUILD_CMDS
 	cd $(BUILD_DIR)/kubos-$(KUBOS_VERSION)/services/nsl-duplex-d2-comms-service && \
 	PATH=$(PATH):~/.cargo/bin:/usr/bin/iobc_toolchain/usr/bin && \
-	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) cargo build --package nsl-duplex-d2-comms-service --target $(CARGO_TARGET) --release
+	PKG_CONFIG_ALLOW_CROSS=1 CC=$(TARGET_CC) RUSTFLAGS="-Clinker=$(TARGET_CC)" cargo build --package nsl-duplex-d2-comms-service --target $(CARGO_TARGET) --release
 endef
 
 # Generate the config settings for the service and add them to a fragment file


### PR DESCRIPTION
On my machine, setting `CC=$(TARGET_CC)` was insufficient for rust to find the correct linker and compile packages. Setting `-Clinker=$(TARGET_CC)` is a more robust way to provide the correct linker to `rustc`.