### PR TITLE
Removing '-b' flag from app service init script

### DIFF
--- a/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service
+++ b/package/kubos/kubos-core/kubos-core-app-service/kubos-core-app-service
@@ -7,7 +7,7 @@ PID=/var/run/${NAME}.pid
 case "$1" in
     start)
     echo "Starting ${NAME}: "
-    start-stop-daemon -q -m -b -p ${PID} --exec ${PROG} -S -- -b
+    start-stop-daemon -q -m -b -p ${PID} --exec ${PROG} -S
     rc=$?
     if [ $rc -eq 0 ]
     then


### PR DESCRIPTION
Run levels and the `-b` "OnBoot" flag for the app service were removed in kubos/kubos#457. This PR updates the app service init script to remove that flag.